### PR TITLE
Remove voice groups from parsed data

### DIFF
--- a/grammar/voices.bnf
+++ b/grammar/voices.bnf
@@ -1,4 +1,4 @@
-voices       = voice (<ows> voice)* (<ows> (voice-zero | <#"\z"> | &<"]">))
+<voices>     = voice (<ows> voice)* (<ows> (voice-zero | <#"\z"> | &<"]">))
 voice        = voice-number <ows> events-inside-voice
 voice-number = <"V"> #"[1-9]\d*" <":">
 voice-zero = <"V0:">

--- a/src/alda/lisp/events.clj
+++ b/src/alda/lisp/events.clj
@@ -107,14 +107,6 @@
    :number     voice-number
    :events     events})
 
-(defn voices
-  "Voices are chronological sequences of events that each start at the same
-   time. The resulting :current-offset is at the end of the voice that finishes
-   last."
-  [& voices]
-  {:event-type :voice-group
-   :voices     voices})
-
 (defn end-voices
   "By default, the score remains in 'voice mode' until it reaches an end-voices
    event. This is so that if an instrument part ends with a voice group, the

--- a/src/alda/lisp/events/voice.clj
+++ b/src/alda/lisp/events/voice.clj
@@ -33,10 +33,6 @@
                      #(if % % instruments)))]
     (reduce update-score score events)))
 
-(defmethod update-score :voice-group
-  [score {:keys [voices] :as voice-group}]
-  (reduce update-score score voices))
-
 (defmethod update-score :end-voice-group
   [score _]
   (end-voice-group score))

--- a/src/alda/parser.clj
+++ b/src/alda/parser.clj
@@ -142,7 +142,6 @@
                       (list 'alda.lisp/times n event))
    :event-sequence  #(vec (list* %&))
    :cram            #(list* 'alda.lisp/cram %&)
-   :voices          #(list* 'alda.lisp/voices %&)
    :voice           (fn [voice-number & events]
                       (list* 'alda.lisp/voice voice-number events))
    :voice-zero      #(list 'alda.lisp/voice 0
@@ -181,7 +180,6 @@
                       (evts/times n event))
    :event-sequence  vector
    :cram            #(apply evts/cram %&)
-   :voices          #(apply evts/voices %&)
    :voice           (fn [voice-number & events]
                       (apply evts/voice
                              voice-number

--- a/test/alda/lisp/variables_test.clj
+++ b/test/alda/lisp/variables_test.clj
@@ -99,9 +99,8 @@
                             #"Undefined variable: bar"
                             (score
                               (set-variable :foo
-                                (voices
-                                  (voice 1
-                                    (get-variable :bar)))))))))
+                                (voice 1
+                                       (get-variable :bar))))))))
   (testing "variables can contain event seqs"
     (let [s (score
               (set-variable :foo [])

--- a/test/alda/lisp/voices_test.clj
+++ b/test/alda/lisp/voices_test.clj
@@ -9,32 +9,30 @@
     (testing "the first note of each voice should all start at the same time"
       (let [s      (score
                      (part "piano"
-                       (voices
-                         (voice 1
-                           (note (pitch :g) (duration (note-length 1))))
-                         (voice 2
-                           (note (pitch :b) (duration (note-length 1))))
-                         (voice 3
-                           (note (pitch :d) (duration (note-length 1)))))))
+                       (voice 1
+                              (note (pitch :g) (duration (note-length 1))))
+                       (voice 2
+                              (note (pitch :b) (duration (note-length 1))))
+                       (voice 3
+                              (note (pitch :d) (duration (note-length 1))))))
             events (-> s :events)]
         (is (= 1 (count (distinct (map :offset events)))))))
     (let [s            (score
                          (part "piano"
-                           (voices
-                             (voice 1
-                               (note (pitch :g) (duration (note-length 1)))
-                               (note (pitch :b) (duration (note-length 2))))
-                             (voice 2
-                               (note (pitch :b) (duration (note-length 1)))
-                               (note (pitch :d) (duration (note-length 1))))
-                             (voice 3
-                               (note (pitch :d) (duration (note-length 1)))
-                               (note (pitch :f) (duration (note-length 4))))
-                             (voice 2
-                               (octave :up)
-                               (octave :down)
-                               (note (pitch :g))
-                               (note (pitch :g))))
+                           (voice 1
+                                  (note (pitch :g) (duration (note-length 1)))
+                                  (note (pitch :b) (duration (note-length 2))))
+                           (voice 2
+                                  (note (pitch :b) (duration (note-length 1)))
+                                  (note (pitch :d) (duration (note-length 1))))
+                           (voice 3
+                                  (note (pitch :d) (duration (note-length 1)))
+                                  (note (pitch :f) (duration (note-length 4))))
+                           (voice 2
+                                  (octave :up)
+                                  (octave :down)
+                                  (note (pitch :g))
+                                  (note (pitch :g)))
                            (end-voices)))
           piano        (get-instrument s "piano")
           events       (-> s :events)
@@ -64,36 +62,35 @@
     (testing "should not throw an exception"
       (is (score
             (part "piano"
-              (voices
-                (voice 1
-                  (cram
-                    (note (pitch :c))
-                    (octave :down)
-                    (note (pitch :b))
-                    (note (pitch :a))
-                    (note (pitch :g))))))))))
+              (voice 1
+                     (cram
+                      (note (pitch :c))
+                      (octave :down)
+                      (note (pitch :b))
+                      (note (pitch :a))
+                      (note (pitch :g)))))))))
   (testing "a voice group"
     (testing "can be repeated manually, closed"
-      (let [vs (voices (voice 1 (note (pitch :a))))
+      (let [vs (voice 1 (note (pitch :a)))
             s (score (part "piano" [vs (end-voices) vs]))]
         (is (= 2 (count (:events s))))))
     (testing "can be repeated manually, unclosed"
-      (let [vs (voices (voice 1 (note (pitch :a))))
+      (let [vs (voice 1 (note (pitch :a)))
             s (score (part "piano" [vs vs]))]
         (is (= 2 (count (:events s))))))
     (testing "can be repeated, closed"
-      (let [s (score (part "piano" (times 2 [(voices (voice 1 (note (pitch :a)))) (end-voices)])))]
+      (let [s (score (part "piano" (times 2 [(voice 1 (note (pitch :a))) (end-voices)])))]
         (is (= 2 (count (:events s))))))
     (testing "can be repeated, unclosed"
-      (let [s (score (part "piano" (times 2 (voices (voice 1 (note (pitch :a)))))))]
+      (let [s (score (part "piano" (times 2 (voice 1 (note (pitch :a))))))]
         (is (= 2 (count (:events s))))))
     (testing "left unclosed, leaves instrument state intact"
-      (let [s (score (part "piano" (times 2 (voices (voice 1 (note (pitch :a)))))))]
+      (let [s (score (part "piano" (times 2 (voice 1 (note (pitch :a))))))]
         (is (not (empty? (:voice-instruments s))))))
     (testing "closed, wipes instrument state"
-      (let [s (score (part "piano" (voices (voice 1 (note (pitch :a))) (end-voices))))]
+      (let [s (score (part "piano" (voice 1 (note (pitch :a))) (end-voices)))]
         (is (empty? (:voice-instruments s)))))
     (testing "on part transition, wipes instrument state"
-      (let [s (score (part "piano" (voices (voice 1 (note (pitch :a))) (part "guitar" (note (pitch :a))))))]
+      (let [s (score (part "piano" (voice 1 (note (pitch :a))) (part "guitar" (note (pitch :a)))))]
         (is (empty? (:voice-instruments s)))))))
 

--- a/test/alda/parser/event_sequences_test.clj
+++ b/test/alda/parser/event_sequences_test.clj
@@ -23,14 +23,13 @@
               (alda.lisp/note (alda.lisp/pitch :g))]))))
   (testing "voices within event sequences parse successfully"
     (is (= (parse-to-lisp-with-context :music-data "[V1: e b d V2: a c f]")
-           '([(alda.lisp/voices
-                (alda.lisp/voice
-                  1
-                  (alda.lisp/note (alda.lisp/pitch :e))
-                  (alda.lisp/note (alda.lisp/pitch :b))
-                  (alda.lisp/note (alda.lisp/pitch :d)))
-                (alda.lisp/voice
-                  2
-                  (alda.lisp/note (alda.lisp/pitch :a))
-                  (alda.lisp/note (alda.lisp/pitch :c))
-                  (alda.lisp/note (alda.lisp/pitch :f))))])))))
+           '([(alda.lisp/voice
+               1
+               (alda.lisp/note (alda.lisp/pitch :e))
+               (alda.lisp/note (alda.lisp/pitch :b))
+               (alda.lisp/note (alda.lisp/pitch :d)))
+              (alda.lisp/voice
+               2
+               (alda.lisp/note (alda.lisp/pitch :a))
+               (alda.lisp/note (alda.lisp/pitch :c))
+               (alda.lisp/note (alda.lisp/pitch :f)))])))))

--- a/test/alda/parser/events_test.clj
+++ b/test/alda/parser/events_test.clj
@@ -48,52 +48,48 @@
   (testing "voices"
     (is (= (parse-to-lisp-with-context :part "piano: V1: a b c")
            '(alda.lisp/part {:names ["piano"]}
-              (alda.lisp/voices
-                (alda.lisp/voice 1
-                  (alda.lisp/note (alda.lisp/pitch :a))
-                  (alda.lisp/note (alda.lisp/pitch :b))
-                  (alda.lisp/note (alda.lisp/pitch :c)))))))
+              (alda.lisp/voice 1
+                               (alda.lisp/note (alda.lisp/pitch :a))
+                               (alda.lisp/note (alda.lisp/pitch :b))
+                               (alda.lisp/note (alda.lisp/pitch :c))))))
     (is (= (parse-to-lisp-with-context :part "piano:
                                         V1: a b c
                                         V2: d e f")
            '(alda.lisp/part {:names ["piano"]}
-              (alda.lisp/voices
-                (alda.lisp/voice 1
-                  (alda.lisp/note (alda.lisp/pitch :a))
-                  (alda.lisp/note (alda.lisp/pitch :b))
-                  (alda.lisp/note (alda.lisp/pitch :c)))
-                (alda.lisp/voice 2
-                  (alda.lisp/note (alda.lisp/pitch :d))
-                  (alda.lisp/note (alda.lisp/pitch :e))
-                  (alda.lisp/note (alda.lisp/pitch :f)))))))
+              (alda.lisp/voice 1
+                               (alda.lisp/note (alda.lisp/pitch :a))
+                               (alda.lisp/note (alda.lisp/pitch :b))
+                               (alda.lisp/note (alda.lisp/pitch :c)))
+              (alda.lisp/voice 2
+                               (alda.lisp/note (alda.lisp/pitch :d))
+                               (alda.lisp/note (alda.lisp/pitch :e))
+                               (alda.lisp/note (alda.lisp/pitch :f))))))
     (is (= (parse-to-lisp-with-context :part "piano:
                                         V1: a b c | V2: d e f")
            '(alda.lisp/part {:names ["piano"]}
-              (alda.lisp/voices
-                (alda.lisp/voice 1
-                  (alda.lisp/note (alda.lisp/pitch :a))
-                  (alda.lisp/note (alda.lisp/pitch :b))
-                  (alda.lisp/note (alda.lisp/pitch :c))
-                  (alda.lisp/barline))
-                (alda.lisp/voice 2
-                  (alda.lisp/note (alda.lisp/pitch :d))
-                  (alda.lisp/note (alda.lisp/pitch :e))
-                  (alda.lisp/note (alda.lisp/pitch :f)))))))
+              (alda.lisp/voice 1
+                               (alda.lisp/note (alda.lisp/pitch :a))
+                               (alda.lisp/note (alda.lisp/pitch :b))
+                               (alda.lisp/note (alda.lisp/pitch :c))
+                               (alda.lisp/barline))
+              (alda.lisp/voice 2
+                               (alda.lisp/note (alda.lisp/pitch :d))
+                               (alda.lisp/note (alda.lisp/pitch :e))
+                               (alda.lisp/note (alda.lisp/pitch :f))))))
     (is (= (parse-to-lisp-with-context :part "piano:
                                         V1: [a b c] *8
                                         V2: [d e f] *8")
            '(alda.lisp/part {:names ["piano"]}
-              (alda.lisp/voices
-                (alda.lisp/voice 1
-                  (alda.lisp/times 8
-                    [(alda.lisp/note (alda.lisp/pitch :a))
-                     (alda.lisp/note (alda.lisp/pitch :b))
-                     (alda.lisp/note (alda.lisp/pitch :c))]))
-                (alda.lisp/voice 2
-                  (alda.lisp/times 8
-                    [(alda.lisp/note (alda.lisp/pitch :d))
-                     (alda.lisp/note (alda.lisp/pitch :e))
-                     (alda.lisp/note (alda.lisp/pitch :f))]))))))))
+              (alda.lisp/voice 1
+                               (alda.lisp/times 8
+                                                [(alda.lisp/note (alda.lisp/pitch :a))
+                                                 (alda.lisp/note (alda.lisp/pitch :b))
+                                                 (alda.lisp/note (alda.lisp/pitch :c))]))
+              (alda.lisp/voice 2
+                               (alda.lisp/times 8
+                                                [(alda.lisp/note (alda.lisp/pitch :d))
+                                                 (alda.lisp/note (alda.lisp/pitch :e))
+                                                 (alda.lisp/note (alda.lisp/pitch :f))])))))))
 
 (deftest marker-tests
   (testing "markers"


### PR DESCRIPTION
This time on the right repo!

From [286](https://github.com/alda-lang/alda/pull/286), cleaning up after myself by removing the `voices` element from the parser tree entirely. It turned out to be as simple as just swallowing the token with `<>`, deleting the handling code for it, and removing it from assertions. The one thing that `:voice-group` does, `assoc :voice-instruments {}`, already seems to be handled by the events for individual voices.

This is intended to cause no behavioral changes in Alda; pure code cleanup.