### PR TITLE
Specify clojure version

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -10,6 +10,7 @@
                     [io.aviso/pretty       "0.1.33" :scope "test"]
 
                     ; alda.core
+                    [org.clojure/clojure    "1.8.0"]
                     [instaparse             "1.4.3"]
                     [com.taoensso/timbre    "4.7.4"]
                     [djy                    "0.1.4"]


### PR DESCRIPTION
Looks like alda-core relies on clojure 1.8.0+, specifically for the [starts-with?](https://clojuredocs.org/clojure.string/starts-with_q) method in the `clojure/string` library.

I was getting the following when trying to run `boot test`:
![screen shot 2017-01-02 at 1 35 56 pm](https://cloud.githubusercontent.com/assets/750477/21583681/eb82bd70-d0f0-11e6-9da6-e89356c87f17.png)

Which was fixed by adding this line 😃 