### PR TITLE
Update tokenize.clj

### DIFF
--- a/src/alda/parser/tokenize.clj
+++ b/src/alda/parser/tokenize.clj
@@ -579,7 +579,8 @@
                    (start-parsing-duration character))
 
         ; else
-        (-> parser (unexpected-char-error character))))))
+        (-> parser (emit-token! :pop-stack? true)
+                   (read-character! character))))))
 
 (defn parse-slash
   [parser character]


### PR DESCRIPTION
If I compared the `parse-note` and `parse-rest` functions correctly, this is the change that you applied for notes to fix the unknown character error being thrown in the `[c d c]` case. This should fix the unknown character error in the `[c d c r]` case.