### PR TITLE
added decimal note/rest lengths

### DIFF
--- a/src/alda/lisp/attributes.clj
+++ b/src/alda/lisp/attributes.clj
@@ -4,7 +4,8 @@
             [alda.lisp.model.attribute :refer (*attribute-table*)]
             [alda.lisp.model.key       :refer (get-key-signature)]
             [alda.lisp.model.records   :refer (->AbsoluteOffset
-                                               ->Attribute)]))
+                                               ->Attribute)]
+            [alda.lisp.model.duration  :refer (note-length)]))
 
 (comment
   "The :attributes key in an instrument functions like the :global-attributes
@@ -79,6 +80,26 @@
 
                    :else
                    {:beats val}))))
+
+;; Converts string/number representation of note length into number of beats
+(defn- parse-note-length
+  [length]
+  {:pre [(or (string? length) (number? length))]}
+  (cond
+    (string? length)
+    (let [[_ number _ dots]  (re-matches #"(\d+(\.\d+)?)(\.*)" length)]
+      (if number
+        (note-length (Float/parseFloat number) {:dots (count dots)})
+        (throw (Exception. (format "Invalid note length: %s" length)))))
+
+    :else
+    (note-length length)))
+
+(defn set-note-length
+  "Sets note duration in terms of alda note-lengths
+   (e.g. quarter note = 4, dotted note = \"4.\")"
+  [length]
+  (set-duration (:value (parse-note-length length))))
 
 (defattribute octave
   "Current octave. Used to calculate the pitch of notes."

--- a/src/alda/parser.clj
+++ b/src/alda/parser.clj
@@ -159,4 +159,3 @@
         (if (instance? Throwable event)
           (throw event)))
       events)))
-

--- a/src/alda/parser/parse_events.clj
+++ b/src/alda/parser/parse_events.clj
@@ -136,7 +136,7 @@
         accidentals    (-> (for [{:keys [type content]} more
                                  :when (= :accidentals type)]
                              (map {\+ :sharp \- :flat \_ :natural} content))
-                            flatten)
+                           flatten)
         pitch          (apply pitch/pitch (keyword (:content letter)) accidentals)
         duration       (-> (for [{:keys [type] :as event} more
                                  :when (= :duration type)]
@@ -150,12 +150,12 @@
 
 (defmethod alda-event :note-length
   [{:keys [content]}]
-  (let [[_ number dots]  (re-matches #"(\d+)(\.*)" content)
+  (let [[_ number _ dots]  (re-matches #"(\d+(\.\d+)?)(\.*)" content)
         [_ seconds]      (re-matches #"(\d+)s" content)
         [_ milliseconds] (re-matches #"(\d+)ms" content)]
     (cond
       number
-      (dur/note-length (Integer/parseInt number) {:dots (count dots)})
+      (dur/note-length (Float/parseFloat number) {:dots (count dots)})
 
       seconds
       (dur/ms (* 1000 (Integer/parseInt seconds)))

--- a/src/alda/parser/tokenize.clj
+++ b/src/alda/parser/tokenize.clj
@@ -114,7 +114,7 @@
     (= :EOF x)
     parser
 
-    (#{\newline "\n"}x)
+    (#{\newline "\n"} x)
     (-> parser next-line)
 
     :else

--- a/src/alda/parser/tokenize.clj
+++ b/src/alda/parser/tokenize.clj
@@ -5,8 +5,7 @@
   {:state          :parsing ; parsing, done, or error
    :line           1
    :column         1
-   :stack          []       ; context for nesting tokens
-   })
+   :stack          []})       ; context for nesting tokens
 
 (defn parser
   [tokens-ch]
@@ -115,7 +114,7 @@
     (= :EOF x)
     parser
 
-    (#{\newline "\n"} x)
+    (#{\newline "\n"}x)
     (-> parser next-line)
 
     :else
@@ -497,7 +496,7 @@
         (-> parser (read-to-buffer character))
 
         #{\.}
-        (if (re-matches #"\d+\.*" buffer)
+        (if (re-matches #"(\d+\.)?\d+\.*" buffer)
           (-> parser (read-to-buffer character))
           (-> parser (unexpected-char-error character)))
 
@@ -574,7 +573,7 @@
         #{\newline}
         (-> parser (parse-newline character) (emit-token! :pop-stack? true))
 
-        #{\1 \2 \3 \4 \5 \6 \7 \8 \9}
+        #{\0 \1 \2 \3 \4 \5 \6 \7 \8 \9}
         (-> parser (emit-token! :pop-stack? true)
                    (start-parsing-duration character))
 

--- a/test/alda/lisp/attributes_test.clj
+++ b/test/alda/lisp/attributes_test.clj
@@ -128,6 +128,16 @@
         (is (== (:beats (:duration piano)) 3.5)))
 
       (let [s     (continue s
+                    (set-note-length 1))
+            piano (get-instrument s "piano")]
+        (is (== (:beats (:duration piano)) 4)))
+
+      (let [s     (continue s
+                    (set-note-length "2.."))
+            piano (get-instrument s "piano")]
+        (is (== (:beats (:duration piano)) 3.5)))
+
+      (let [s     (continue s
                     (note (pitch :c)
                           (duration (note-length 1) (note-length 1))))
             piano (get-instrument s "piano")]

--- a/test/alda/parser/duration_test.clj
+++ b/test/alda/parser/duration_test.clj
@@ -7,14 +7,22 @@
     (is (= (parse-input "c2" :output :events)
            [(alda.lisp/note
               (alda.lisp/pitch :c)
-              (alda.lisp/duration (alda.lisp/note-length 2)))]))))
+              (alda.lisp/duration (alda.lisp/note-length 2)))]))
+    (is (= (parse-input "c0.5" :output :events)
+           [(alda.lisp/note
+              (alda.lisp/pitch :c)
+              (alda.lisp/duration (alda.lisp/note-length 0.5)))]))))
 
 (deftest dot-tests
   (testing "dots"
     (is (= (parse-input "c2.." :output :events)
            [(alda.lisp/note
               (alda.lisp/pitch :c)
-              (alda.lisp/duration (alda.lisp/note-length 2 {:dots 2})))]))))
+              (alda.lisp/duration (alda.lisp/note-length 2 {:dots 2})))]))
+    (is (= (parse-input "c0.5.." :output :events)
+           [(alda.lisp/note
+              (alda.lisp/pitch :c)
+              (alda.lisp/duration (alda.lisp/note-length 0.5 {:dots 2})))]))))
 
 (deftest millisecond-duration-tests
   (testing "duration in milliseconds"
@@ -31,13 +39,19 @@
               (alda.lisp/duration (alda.lisp/ms 2000)))]))))
 
 (deftest tie-and-slur-tests
-  (testing "ties"
+  (testing "ties and slurs"
     (testing "ties"
       (is (= (parse-input "c1~2~4" :output :events)
              [(alda.lisp/note
                 (alda.lisp/pitch :c)
                 (alda.lisp/duration (alda.lisp/note-length 1)
                                     (alda.lisp/note-length 2)
+                                    (alda.lisp/note-length 4)))]))
+      (is (= (parse-input "c1.5~2.5~4" :output :events)
+             [(alda.lisp/note
+                (alda.lisp/pitch :c)
+                (alda.lisp/duration (alda.lisp/note-length 1.5)
+                                    (alda.lisp/note-length 2.5)
                                     (alda.lisp/note-length 4)))]))
       (is (= (parse-input "c500ms~350ms" :output :events)
              [(alda.lisp/note

--- a/test/alda/parser/duration_test.clj
+++ b/test/alda/parser/duration_test.clj
@@ -39,40 +39,39 @@
               (alda.lisp/duration (alda.lisp/ms 2000)))]))))
 
 (deftest tie-and-slur-tests
-  (testing "ties and slurs"
-    (testing "ties"
-      (is (= (parse-input "c1~2~4" :output :events)
-             [(alda.lisp/note
-                (alda.lisp/pitch :c)
-                (alda.lisp/duration (alda.lisp/note-length 1)
-                                    (alda.lisp/note-length 2)
-                                    (alda.lisp/note-length 4)))]))
-      (is (= (parse-input "c1.5~2.5~4" :output :events)
-             [(alda.lisp/note
-                (alda.lisp/pitch :c)
-                (alda.lisp/duration (alda.lisp/note-length 1.5)
-                                    (alda.lisp/note-length 2.5)
-                                    (alda.lisp/note-length 4)))]))
-      (is (= (parse-input "c500ms~350ms" :output :events)
-             [(alda.lisp/note
-                (alda.lisp/pitch :c)
-                (alda.lisp/duration (alda.lisp/ms 500)
-                                    (alda.lisp/ms 350)))]))
-      (is (= (parse-input "c5s~4~350ms" :output :events)
-             [(alda.lisp/note
-                (alda.lisp/pitch :c)
-                (alda.lisp/duration (alda.lisp/ms 5000)
-                                    (alda.lisp/note-length 4)
-                                    (alda.lisp/ms 350)))])))
-    (testing "slurs"
-      (is (= (parse-input "c4~" :output :events)
-             [(alda.lisp/note
-                (alda.lisp/pitch :c)
-                (alda.lisp/duration (alda.lisp/note-length 4))
-                :slur)]))
-      (is (= (parse-input "c420ms~" :output :events)
-             [(alda.lisp/note
-                (alda.lisp/pitch :c)
-                (alda.lisp/duration (alda.lisp/ms 420))
-                :slur)])))))
+  (testing "ties"
+    (is (= (parse-input "c1~2~4" :output :events)
+           [(alda.lisp/note
+              (alda.lisp/pitch :c)
+              (alda.lisp/duration (alda.lisp/note-length 1)
+                                  (alda.lisp/note-length 2)
+                                  (alda.lisp/note-length 4)))]))
+    (is (= (parse-input "c1.5~2.5~4" :output :events)
+           [(alda.lisp/note
+              (alda.lisp/pitch :c)
+              (alda.lisp/duration (alda.lisp/note-length 1.5)
+                                  (alda.lisp/note-length 2.5)
+                                  (alda.lisp/note-length 4)))]))
+    (is (= (parse-input "c500ms~350ms" :output :events)
+           [(alda.lisp/note
+              (alda.lisp/pitch :c)
+              (alda.lisp/duration (alda.lisp/ms 500)
+                                  (alda.lisp/ms 350)))]))
+    (is (= (parse-input "c5s~4~350ms" :output :events)
+           [(alda.lisp/note
+              (alda.lisp/pitch :c)
+              (alda.lisp/duration (alda.lisp/ms 5000)
+                                  (alda.lisp/note-length 4)
+                                  (alda.lisp/ms 350)))])))
+  (testing "slurs"
+    (is (= (parse-input "c4~" :output :events)
+           [(alda.lisp/note
+              (alda.lisp/pitch :c)
+              (alda.lisp/duration (alda.lisp/note-length 4))
+              :slur)]))
+    (is (= (parse-input "c420ms~" :output :events)
+           [(alda.lisp/note
+              (alda.lisp/pitch :c)
+              (alda.lisp/duration (alda.lisp/ms 420))
+              :slur)]))))
 


### PR DESCRIPTION
For [issue #16](https://github.com/alda-lang/alda-core/issues/16). I also allowed for decimal rest lengths since they are parsed similarly to note lengths. 

Thank you for providing some low-hanging fruit for those of us just starting out.

To follow up, should expressing length in seconds also be allowed in decimals (e.g. 2.5s)? I think millisecond values have to be integers, though.
As for the set-note-length function discussed in the issue, I noticed that [in the documentation](https://github.com/alda-lang/alda/blob/master/doc/attributes.md) you suggest just calling the note-length function inside set-duration. Would you still like to add set-note-length as a convenience function of sorts?
