### PR TITLE
Reference pitch and transposition

### DIFF
--- a/src/alda/lisp/attributes.clj
+++ b/src/alda/lisp/attributes.clj
@@ -229,3 +229,9 @@
    :aliases [:key-sig]
    :initial-val {}
    :transform parse-key-signature)
+
+(defattribute reference-pitch
+  "The A4 pitch that instruments are tuned around."
+  :aliases [:tuning-constant]
+  :initial-val 440.0
+  :transform pos-num)

--- a/src/alda/lisp/attributes.clj
+++ b/src/alda/lisp/attributes.clj
@@ -234,6 +234,14 @@
    :initial-val {}
    :transform parse-key-signature)
 
+(defattribute transposition
+  "Increases/decreases notes by a certain number of pitches"
+  :aliases [:transpose]
+  :initial-val 0
+  :transform (fn [x]
+               {:pre [integer? x]}
+               (constantly x)))
+
 (defattribute reference-pitch
   "The A4 pitch that instruments are tuned around."
   :aliases [:tuning-constant]

--- a/src/alda/lisp/attributes.clj
+++ b/src/alda/lisp/attributes.clj
@@ -235,11 +235,11 @@
    :transform parse-key-signature)
 
 (defattribute transposition
-  "Increases/decreases notes by a certain number of pitches"
+  "Increments or decrements each note by the desired number of half-steps."
   :aliases [:transpose]
   :initial-val 0
   :transform (fn [x]
-               {:pre [integer? x]}
+               {:pre [(integer? x)]}
                (constantly x)))
 
 (defattribute reference-pitch

--- a/src/alda/lisp/events/note.clj
+++ b/src/alda/lisp/events/note.clj
@@ -25,7 +25,7 @@
   (for [{:keys [id duration duration-inside-cram time-scaling tempo
                 current-offset last-offset current-marker quantization volume
                 track-volume panning octave key-signature reference-pitch
-                min-duration]
+                transposition min-duration]
          :as inst}
         (get-current-instruments score)]
     (let [{:keys [beats ms]} (if (or beats ms)
@@ -38,7 +38,8 @@
                                                  ms)
           quant-duration     (* full-duration quant)
           midi-note          (if (= event-type :note)
-                               (determine-midi-note event octave key-signature))
+                               (determine-midi-note event octave key-signature
+                                transposition))
           pitch              (if (= event-type :note)
                                (midi->hz reference-pitch midi-note))
           note               (if (= event-type :note)

--- a/src/alda/lisp/events/note.clj
+++ b/src/alda/lisp/events/note.clj
@@ -24,7 +24,8 @@
    {:keys [event-type beats ms slur?] :as event}]
   (for [{:keys [id duration duration-inside-cram time-scaling tempo
                 current-offset last-offset current-marker quantization volume
-                track-volume panning octave key-signature min-duration]
+                track-volume panning octave key-signature reference-pitch
+                min-duration]
          :as inst}
         (get-current-instruments score)]
     (let [{:keys [beats ms]} (if (or beats ms)
@@ -39,7 +40,7 @@
           midi-note          (if (= event-type :note)
                                (determine-midi-note event octave key-signature))
           pitch              (if (= event-type :note)
-                               (midi->hz midi-note))
+                               (midi->hz reference-pitch midi-note))
           note               (if (= event-type :note)
                                (map->Note
                                  {:offset       current-offset

--- a/src/alda/lisp/model/pitch.clj
+++ b/src/alda/lisp/model/pitch.clj
@@ -28,9 +28,6 @@
   "Determines the MIDI note number of a note, within the context of an
    instrument's octave and key signature."
   [{:keys [letter accidentals] :as note} octave key-sig transpose]
-
-  ; check if note value in proper range after transpose
-  {:post [<= 0 % 127]}
   (+ transpose
      (reduce (fn [number accidental]
             (case accidental

--- a/src/alda/lisp/model/pitch.clj
+++ b/src/alda/lisp/model/pitch.clj
@@ -11,8 +11,8 @@
 
 (defn midi->hz
   "Converts a MIDI note number to the note's frequency in Hz."
-  [note]
-  (* 440.0 (Math/pow 2.0 (/ (- note 69.0) 12.0))))
+  [ref-pitch note]
+  (* ref-pitch (Math/pow 2.0 (/ (- note 69.0) 12.0))))
 
 (defn- apply-key
   "Modifies the accidentals on notes to fit the key signature.

--- a/src/alda/lisp/model/pitch.clj
+++ b/src/alda/lisp/model/pitch.clj
@@ -27,14 +27,18 @@
 (defn determine-midi-note
   "Determines the MIDI note number of a note, within the context of an
    instrument's octave and key signature."
-  [{:keys [letter accidentals] :as note} octave key-sig]
-  (reduce (fn [number accidental]
+  [{:keys [letter accidentals] :as note} octave key-sig transpose]
+
+  ; check if note value in proper range after transpose
+  {:post [<= 0 % 127]}
+  (+ transpose
+     (reduce (fn [number accidental]
             (case accidental
               :flat    (dec number)
               :sharp   (inc number)
               :natural (identity number)))
           (midi-note letter octave)
-          (apply-key key-sig letter accidentals)))
+          (apply-key key-sig letter accidentals))))
 
 (defn pitch
   [letter & accidentals]

--- a/test/alda/lisp/pitch_test.clj
+++ b/test/alda/lisp/pitch_test.clj
@@ -27,6 +27,28 @@
     (is (== (calculate-pitch :c [:sharp :flat :flat :sharp] 4 {})
             (calculate-pitch :c [] 4 {})))))
 
+(deftest ref-pitch-tests
+  (testing "reference pitch/tuning constant attribute"
+    ; default A4 pitch is 440 Hz
+    (let [s       (score
+                    (part "piano"))
+          piano   (get-instrument s "piano")
+          c4-def  (calculate-pitch :c [] 4 {}
+                    {:ref-pitch (:reference-pitch piano)})]
+
+      (is (== 440 (calculate-pitch :a [] 4 {}
+                    {:ref-pitch (:reference-pitch piano)})))
+
+      (let [s     (continue s
+                    (tuning-constant 430))
+            piano (get-instrument s "piano")]
+        (is (== 430 (calculate-pitch :a [] 4 {}
+                    {:ref-pitch (:reference-pitch piano)}))
+
+        (is (< (calculate-pitch :c [] 4 {}
+                    {:ref-pitch (:reference-pitch piano)})
+               c4-def)))))))
+
 (deftest key-tests
   (testing "you can set and get a key signature"
     (let [s     (score

--- a/test/alda/lisp/pitch_test.clj
+++ b/test/alda/lisp/pitch_test.clj
@@ -29,25 +29,41 @@
 
 (deftest ref-pitch-tests
   (testing "reference pitch/tuning constant attribute"
+    (is (== 430 (calculate-pitch :a [] 4 {} {:ref-pitch 430})))
+    (is (> (calculate-pitch :c [] 4 {})
+           (calculate-pitch :c [] 4 {} {:ref-pitch 430})))
+
     ; default A4 pitch is 440 Hz
     (let [s       (score
                     (part "piano"))
-          piano   (get-instrument s "piano")
-          c4-def  (calculate-pitch :c [] 4 {}
-                    {:ref-pitch (:reference-pitch piano)})]
+          piano   (get-instrument s "piano")]
 
-      (is (== 440 (calculate-pitch :a [] 4 {}
-                    {:ref-pitch (:reference-pitch piano)})))
+      (is (== 440 (:reference-pitch piano)))
 
       (let [s     (continue s
                     (tuning-constant 430))
             piano (get-instrument s "piano")]
-        (is (== 430 (calculate-pitch :a [] 4 {}
-                    {:ref-pitch (:reference-pitch piano)}))
+        (is (== 430 (:reference-pitch piano)))))))
 
-        (is (< (calculate-pitch :c [] 4 {}
-                    {:ref-pitch (:reference-pitch piano)})
-               c4-def)))))))
+(deftest transposition-tests
+  (testing "transposition attribute"
+    (is (== (calculate-pitch :a [] 4 {})
+            (calculate-pitch :g [] 4 {} {:transpose 2})
+            (calculate-pitch :c [] 5 {} {:transpose -3})))
+    (is (== (calculate-pitch :c [] 4 {})
+            (calculate-pitch :b [] 3 {} {:transpose 1})
+            (calculate-pitch :c [:sharp] 4 {} {:transpose -1})
+            (calculate-pitch :c [] 4 {:c [:sharp]} {:transpose -1})))
+
+    (let [s       (score
+                    (part "piano"))
+          piano   (get-instrument s "piano")]
+      (is (== 0 (:transposition piano)))
+
+      (let [s     (continue s
+                    (transpose 2))
+            piano (get-instrument s "piano")]
+        (is (== 2 (:transposition piano)))))))
 
 (deftest key-tests
   (testing "you can set and get a key signature"

--- a/test/alda/test_helpers.clj
+++ b/test/alda/test_helpers.clj
@@ -23,9 +23,11 @@
   (calculate-duration beats tempo (or time-scaling 1) ms))
 
 (defn calculate-pitch
-  [letter accidentals octave key-sig & [{:keys [ref-pitch] :or {ref-pitch 440}}]]
+  [letter accidentals octave key-sig & [{:keys [ref-pitch transpose]
+                                         :or {ref-pitch 440 transpose 0}}]]
   (let [midi-note (determine-midi-note {:letter letter
                                         :accidentals accidentals}
                                        octave
-                                       key-sig)]
+                                       key-sig
+                                       transpose)]
     (midi->hz ref-pitch midi-note)))

--- a/test/alda/test_helpers.clj
+++ b/test/alda/test_helpers.clj
@@ -23,9 +23,9 @@
   (calculate-duration beats tempo (or time-scaling 1) ms))
 
 (defn calculate-pitch
-  [letter accidentals octave key-sig]
+  [letter accidentals octave key-sig & [{:keys [ref-pitch] :or {ref-pitch 440}}]]
   (let [midi-note (determine-midi-note {:letter letter
                                         :accidentals accidentals}
                                        octave
                                        key-sig)]
-    (midi->hz midi-note)))
+    (midi->hz ref-pitch midi-note)))


### PR DESCRIPTION
For issue #21 .
Just to make sure, Alda _does_ use the `midi-note` and `pitch` of a note to determine what to actually play, right?