### PR TITLE
Fix launching workers when alda path has spaces

### DIFF
--- a/src/alda/util.clj
+++ b/src/alda/util.clj
@@ -120,7 +120,7 @@
    (source: http://stackoverflow.com/a/13276993/2338327)"
   [& [ns]]
   (-> (or ns (class *ns*))
-      .getProtectionDomain .getCodeSource .getLocation .getPath))
+      .getProtectionDomain .getCodeSource .getLocation .toURI .getPath))
 
 (defn alda-home-path
   "Returns the path to a folder/file inside the Alda home directory, or the


### PR DESCRIPTION
The program-path function used to return a path where spaces were URL encoded as '%20a' causing an exception when the server was trying to spawn workers if the alda binary path had spaces, for example if it was placed in the notorious Windows "Program Files" directory.

As mentioned in Stackoverflow:
https://stackoverflow.com/questions/320542/how-to-get-the-path-of-a-running-jar-file
"The toURI() step is vital to avoid problems with special characters,
including spaces and pluses."

This could resolve problems described in issue https://github.com/alda-lang/alda-core/issues/31.